### PR TITLE
Do not run Travis OS X packaging job on PRs (test)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -147,7 +147,8 @@ matrix:
       - brew update --debug --verbose
       - brew install opam gnu-time
 
-    - os: osx
+    - if: NOT type IS pull_request
+      os: osx
       osx_image: xcode8.3
       env:
       - TEST_TARGET=""


### PR DESCRIPTION
This job was useless anyway because the depoly and pre-deploy phases were not run.